### PR TITLE
Feature: batch messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 var port = os.Getenv("PORT")
 var logGroupName = os.Getenv("LOG_GROUP_NAME")
-var streamName = uuid.NewV4().String()
+var streamName, err = uuid.NewV4()
 var sequenceToken = ""
 
 var (
@@ -87,7 +87,7 @@ func sendToCloudWatch(buffer []syslog.LogParts) {
 
 	params := &cloudwatchlogs.PutLogEventsInput{
 		LogGroupName:  aws.String(logGroupName),
-		LogStreamName: aws.String(streamName),
+		LogStreamName: aws.String(streamName.String()),
 	}
 
 	for _, logPart := range buffer {
@@ -118,7 +118,7 @@ func initCloudWatchStream() {
 
 	_, err := svc.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  aws.String(logGroupName),
-		LogStreamName: aws.String(streamName),
+		LogStreamName: aws.String(streamName.String()),
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/satori/go.uuid"
 
 	"gopkg.in/mcuadros/go-syslog.v2"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
 var port = os.Getenv("PORT")
@@ -79,7 +80,7 @@ func main() {
 	server.Wait()
 }
 
-func sendToCloudWatch(buffer []syslog.LogParts) {
+func sendToCloudWatch(buffer []format.LogParts) {
 	// service is defined at run time to avoid session expiry in long running processes
 	var svc = cloudwatchlogs.New(session.New())
 	// set the AWS SDK to use our bundled certs for the minimal container (certs from CoreOS linux)


### PR DESCRIPTION
When the log velocity is higher than 5 msg/sec, CloudWatch Logs throws throttling errors. Instead, we should call `PutLogEvents` only once every 200 msec and send all the messages we have collected so far.

Aside, `PutLogEvents` errors will crash the server as it tries to access the response sequence token of an error, but that is a symptom of a problem and not the actual problem. This patch does not fix that problem, just cause it to happen less often as we no longer expect throttling errors - we will crash on other errors, though, for example - if [the batch size is larger than 1 MB](https://docs.aws.amazon.com/en_us/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).